### PR TITLE
fixed a port compatibility bug

### DIFF
--- a/graphic_scene.py
+++ b/graphic_scene.py
@@ -48,7 +48,7 @@ class GraphicsScene(QGraphicsScene):
         z = newObject["z"]
         width = newObject["width"]
         height = newObject["height"]
-        component_name = newObject["component_name"]
+        component_name = convert(newObject["component_name"])
         parameters = newObject["parameters"]
         connected_objects = newObject["connected_objects"]
         parent = newObject["parent_name"]

--- a/lineDrawer.py
+++ b/lineDrawer.py
@@ -113,6 +113,8 @@ class LineDrawer(QWidget):
         if not parent or not child:
             return -1
 
+        print(child.instance_ports)
+
         key1 = ("parent", child.name, parent_port_name, child_port_name)
         key2 = ("child", parent.name, child_port_name, parent_port_name)
         if portsCompatible(parent.instance_ports[parent_port_name]['Value'],

--- a/lineDrawer.py
+++ b/lineDrawer.py
@@ -113,8 +113,6 @@ class LineDrawer(QWidget):
         if not parent or not child:
             return -1
 
-        print(child.instance_ports)
-
         key1 = ("parent", child.name, parent_port_name, child_port_name)
         key2 = ("child", parent.name, child_port_name, parent_port_name)
         if portsCompatible(parent.instance_ports[parent_port_name]['Value'],

--- a/m5_calls.py
+++ b/m5_calls.py
@@ -27,7 +27,7 @@ def get_port_info(m5_object):
     port_dict = {} #Save port info for the objects
     for port_name, port in m5_object._ports.items():
         port_attr = {"Description": port.desc, 'Name': port_name, \
-        'Value': port,  'Type': Port}
+        'Value': port, 'Default': port, 'Type': Port}
 
         port_dict[port_name] = port_attr
     return port_dict

--- a/sym_object.py
+++ b/sym_object.py
@@ -162,7 +162,7 @@ class SymObject(QGraphicsItemGroup):
         # Some parameters are included in the class but not in the actual instance_params
         #   given in enumerateParams TODO: look into this!!!
         weird_params = []
-        print(port_dict)
+        
         for port, port_info in self.instance_ports.items():
             port_info["Description"] = port_dict[port]["Description"]
             port_info["Default"] = port_dict[port]["Default"]

--- a/sym_object.py
+++ b/sym_object.py
@@ -157,13 +157,16 @@ class SymObject(QGraphicsItemGroup):
         else:
             self.sim_object_instance = self.sim_object()
         param_dict = self.sim_object_instance._params
-        port_dict = self.sim_object_instance._ports
+        port_dict = get_port_info(self.sim_object_instance)
 
         # Some parameters are included in the class but not in the actual instance_params
         #   given in enumerateParams TODO: look into this!!!
         weird_params = []
-
+        print(port_dict)
         for port, port_info in self.instance_ports.items():
+            port_info["Description"] = port_dict[port]["Description"]
+            port_info["Default"] = port_dict[port]["Default"]
+            port_info["Type"] = port_dict[port]["Type"]
             if port_info["Value"] == None:
                 port_info["Value"] = port_dict.get(port) #load default port
 

--- a/wire.py
+++ b/wire.py
@@ -60,7 +60,9 @@ class Wire(QGraphicsItemGroup):
 
         parent = self.state.sym_objects[self.child_key[1]]
         child = self.state.sym_objects[self.parent_key[1]]
-        parent.instance_ports[self.parent_key[2]]['Value'] = None
+        print(parent.instance_ports)
+        parent.instance_ports[self.parent_key[2]]['Value'] = parent.instance_ports[self.parent_key[2]]['Default']
+        child.instance_ports[self.child_key[2]]['Value'] = child.instance_ports[self.child_key[2]]['Default']
         del parent.ui_connections[self.parent_key]
         del child.ui_connections[self.child_key]
         self.state.scene.removeItem(self)


### PR DESCRIPTION
When creating a wire, deleting it, and creating a new wire, the incompatibility flag would be raised erroneously. This fixes it.