### PR TITLE
fixed bug with detaching children

### DIFF
--- a/example/working_nocache.ui
+++ b/example/working_nocache.ui
@@ -33,8 +33,8 @@
             "connections": [], 
             "width": 150.0, 
             "connected_objects": [], 
-            "y": 727.0, 
-            "x": 1089.0, 
+            "y": 714.0, 
+            "x": 1125.0, 
             "z": 3, 
             "ports": {}, 
             "component_name": "Process"
@@ -60,8 +60,8 @@
                         "int_master", 
                         "slave"
                     ], 
-                    "parent_endpoint_x": 1019.125, 
-                    "parent_endpoint_y": 768.5, 
+                    "parent_endpoint_x": 1064.125, 
+                    "parent_endpoint_y": 795.5, 
                     "child_endpoint_y": 505.5, 
                     "child_endpoint_x": 1074.125
                 }, 
@@ -74,8 +74,8 @@
                         "pio", 
                         "master"
                     ], 
-                    "parent_endpoint_x": 1019.125, 
-                    "parent_endpoint_y": 802.5, 
+                    "parent_endpoint_x": 1064.125, 
+                    "parent_endpoint_y": 829.5, 
                     "child_endpoint_y": 488.5, 
                     "child_endpoint_x": 1074.125
                 }, 
@@ -88,16 +88,16 @@
                         "int_slave", 
                         "master"
                     ], 
-                    "parent_endpoint_x": 1019.125, 
-                    "parent_endpoint_y": 785.5, 
+                    "parent_endpoint_x": 1064.125, 
+                    "parent_endpoint_y": 812.5, 
                     "child_endpoint_y": 488.5, 
                     "child_endpoint_x": 1074.125
                 }
             ], 
             "width": 150.0, 
             "connected_objects": [], 
-            "y": 741.0, 
-            "x": 893.0, 
+            "y": 768.0, 
+            "x": 938.0, 
             "z": 3, 
             "ports": {
                 "int_slave": {
@@ -139,8 +139,8 @@
             "connections": [], 
             "width": 150.0, 
             "connected_objects": [], 
-            "y": 649.5, 
-            "x": 914.5, 
+            "y": 676.5, 
+            "x": 950.5, 
             "z": 3, 
             "ports": {}, 
             "component_name": "X86ISA"
@@ -174,9 +174,9 @@
                 }, 
                 "init_param": {}, 
                 "multi_thread": {}, 
-                "exit_on_work_items": {}, 
+                "work_begin_cpu_id_exit": {}, 
                 "work_item_id": {}, 
-                "work_begin_cpu_id_exit": {}
+                "exit_on_work_items": {}
             }, 
             "height": 410.5, 
             "connections": [
@@ -245,8 +245,8 @@
                         "slave", 
                         "icache_port"
                     ], 
-                    "parent_endpoint_x": 1260.625, 
-                    "parent_endpoint_y": 823.0, 
+                    "parent_endpoint_x": 1296.625, 
+                    "parent_endpoint_y": 810.0, 
                     "child_endpoint_y": 505.5, 
                     "child_endpoint_x": 1074.125
                 }, 
@@ -287,8 +287,8 @@
                         "master", 
                         "int_slave"
                     ], 
-                    "parent_endpoint_x": 1019.125, 
-                    "parent_endpoint_y": 785.5, 
+                    "parent_endpoint_x": 1064.125, 
+                    "parent_endpoint_y": 812.5, 
                     "child_endpoint_y": 488.5, 
                     "child_endpoint_x": 1074.125
                 }, 
@@ -301,8 +301,8 @@
                         "slave", 
                         "dcache_port"
                     ], 
-                    "parent_endpoint_x": 1260.625, 
-                    "parent_endpoint_y": 731.0, 
+                    "parent_endpoint_x": 1296.625, 
+                    "parent_endpoint_y": 718.0, 
                     "child_endpoint_y": 505.5, 
                     "child_endpoint_x": 1074.125
                 }, 
@@ -315,8 +315,8 @@
                         "master", 
                         "pio"
                     ], 
-                    "parent_endpoint_x": 1019.125, 
-                    "parent_endpoint_y": 802.5, 
+                    "parent_endpoint_x": 1064.125, 
+                    "parent_endpoint_y": 829.5, 
                     "child_endpoint_y": 488.5, 
                     "child_endpoint_x": 1074.125
                 }, 
@@ -329,8 +329,8 @@
                         "slave", 
                         "int_master"
                     ], 
-                    "parent_endpoint_x": 1019.125, 
-                    "parent_endpoint_y": 768.5, 
+                    "parent_endpoint_x": 1064.125, 
+                    "parent_endpoint_y": 795.5, 
                     "child_endpoint_y": 505.5, 
                     "child_endpoint_x": 1074.125
                 }
@@ -344,10 +344,10 @@
                 "default": {
                     "Value": null
                 }, 
-                "slave": {
+                "master": {
                     "Value": null
                 }, 
-                "master": {
+                "slave": {
                     "Value": null
                 }
             }, 
@@ -357,7 +357,6 @@
             "parent_name": "sys", 
             "name": "mem_ctrl", 
             "parameters": {
-                "tRP": {}, 
                 "tRFC": {}, 
                 "activation_limit": {}, 
                 "IDD3N2": {}, 
@@ -365,12 +364,12 @@
                 "tWTR": {}, 
                 "enable_dram_powerdown": {}, 
                 "IDD52": {}, 
-                "clk_domain": {}, 
                 "write_low_thresh_perc": {}, 
                 "write_buffer_size": {}, 
                 "qos_syncro_scheduler": {}, 
                 "VDD": {}, 
                 "write_high_thresh_perc": {}, 
+                "static_frontend_latency": {}, 
                 "IDD3P12": {}, 
                 "bank_groups_per_rank": {}, 
                 "IDD2N2": {}, 
@@ -385,10 +384,12 @@
                 "tRTP": {}, 
                 "dll": {}, 
                 "tWR": {}, 
-                "IDD2P02": {}, 
+                "mem_sched_policy": {}, 
+                "tRP": {}, 
                 "eventq_index": {}, 
                 "devices_per_rank": {}, 
-                "static_backend_latency": {}, 
+                "IDD2P02": {}, 
+                "IDD4R2": {}, 
                 "banks_per_rank": {}, 
                 "IDD5": {}, 
                 "tXP": {}, 
@@ -415,9 +416,8 @@
                 "tRAS": {}, 
                 "IDD6": {}, 
                 "tBURST": {}, 
-                "static_frontend_latency": {}, 
-                "device_bus_width": {}, 
-                "IDD4R2": {}, 
+                "clk_domain": {}, 
+                "qos_q_policy": {}, 
                 "tXS": {}, 
                 "addr_mapping": {}, 
                 "IDD3P0": {}, 
@@ -434,9 +434,9 @@
                 "tXAW": {}, 
                 "IDD2P12": {}, 
                 "VDD2": {}, 
-                "qos_q_policy": {}, 
+                "device_bus_width": {}, 
                 "qos_policy": {}, 
-                "mem_sched_policy": {}, 
+                "static_backend_latency": {}, 
                 "IDD4W": {}, 
                 "IDD4R": {}, 
                 "tXPDLL": {}
@@ -548,8 +548,8 @@
                         "icache_port", 
                         "slave"
                     ], 
-                    "parent_endpoint_x": 1260.625, 
-                    "parent_endpoint_y": 823.0, 
+                    "parent_endpoint_x": 1296.625, 
+                    "parent_endpoint_y": 810.0, 
                     "child_endpoint_y": 505.5, 
                     "child_endpoint_x": 1074.125
                 }, 
@@ -562,8 +562,8 @@
                         "dcache_port", 
                         "slave"
                     ], 
-                    "parent_endpoint_x": 1260.625, 
-                    "parent_endpoint_y": 731.0, 
+                    "parent_endpoint_x": 1296.625, 
+                    "parent_endpoint_y": 718.0, 
                     "child_endpoint_y": 505.5, 
                     "child_endpoint_x": 1074.125
                 }
@@ -574,8 +574,8 @@
                 "isa", 
                 "workload"
             ], 
-            "y": 666.0, 
-            "x": 893.0, 
+            "y": 653.0, 
+            "x": 929.0, 
             "z": 2, 
             "ports": {
                 "icache_port": {

--- a/sym_object.py
+++ b/sym_object.py
@@ -589,10 +589,6 @@ class SymObject(QGraphicsItemGroup):
             self.setCursor(QCursor(Qt.PointingHandCursor))
         super(SymObject, self).mouseReleaseEvent(event)
 
-        # if object has not moved
-        if self.x == self.pos().x() and self.y == self.pos().y():
-            return
-
         self.setParentConnection()
         for object in self.state.symObjects.values():
             object.setZValue(object.z)


### PR DESCRIPTION
removed block of code from mouseReleaseEvent in sym_object.py that was preventing an objects children from being detached if it was just clicked on (and not moved)